### PR TITLE
Update package.json main field & some types

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -17,6 +17,19 @@
   </head>
   <body>
     <h1>Color Legend Element</h1>
+
     <color-legend></color-legend>
+
+    <hr style="margin: 1rem 0" />
+
+    <!-- Note that when passing objects or arrays to attributes they are assumed to be JSON.stringified -->
+    <color-legend
+      titletext="My categorical legend"
+      class="js-categorical"
+      scaletype="categorical"
+      domain='["a","b"]'
+      range='["red","blue"]'
+      markType="line"
+    ></color-legend>
   </body>
 </html>

--- a/dev/index.html
+++ b/dev/index.html
@@ -16,6 +16,7 @@
     <script type="module" src="../build/color-legend-element.js"></script>
   </head>
   <body>
+    <h1>Color Legend Element</h1>
     <color-legend></color-legend>
   </body>
 </html>

--- a/docs/assets/color-legend-element.umd.js
+++ b/docs/assets/color-legend-element.umd.js
@@ -37,7 +37,7 @@ const st=(t,i)=>"method"===i.kind&&i.descriptor&&!("value"in i.descriptor)?{...i
      * @license
      * Copyright 2017 Google LLC
      * SPDX-License-Identifier: BSD-3-Clause
-     */}class ot{constructor(t){this.cle=t}setColorScale(){switch(this.cle.scaleType){case"continuous":this.setContinousColorScale();break;case"discrete":this.setDiscreteColorScale();break;case"threshold":this.setThresholdColorScale();break;case"categorical":this.setCategoricalColorScale();break;default:this.invalidScaleType(this.cle.scaleType)}}setContinousColorScale(){const{interpolator:t,domain:s,range:n}=this.cle;this.colorScale=t?i.scaleSequential(t).domain(s):i.scaleLinear().range(n).domain(s).interpolate(e.interpolateHcl)}setDiscreteColorScale(){this.colorScale=i.scaleQuantize().domain(this.cle.domain).range(this.cle.range)}setThresholdColorScale(){const t=this.cle.domain;this.colorScale=i.scaleThreshold().domain(t.slice(1,t.length-1)).range(this.cle.range)}setCategoricalColorScale(){this.colorScale=i.scaleOrdinal().domain(this.cle.domain).range(this.cle.range)}invalidScaleType(t){throw new Error(`invalid property scaletype: ${t}. \n      Must be one of "categorical", "continuous", "discrete", "threshold".`)}}
+     */}class ot{constructor(t){this.cle=t}setColorScale(){switch(this.cle.scaleType){case"continuous":this.setContinousColorScale();break;case"discrete":this.setDiscreteColorScale();break;case"threshold":this.setThresholdColorScale();break;case"categorical":this.setCategoricalColorScale();break;default:this.invalidScaleType(this.cle.scaleType)}}setContinousColorScale(){const{interpolator:t,domain:s,range:n}=this.cle;this.colorScale=t?i.scaleSequential(t).domain(s):i.scaleLinear().range(n).domain(s).interpolate(e.interpolateHcl)}setDiscreteColorScale(){this.colorScale=i.scaleQuantize().domain(this.cle.domain).range(this.cle.range)}setThresholdColorScale(){const t=this.cle.domain;this.colorScale=i.scaleThreshold().domain(t.slice(1,t.length-1)).range(this.cle.range)}setCategoricalColorScale(){this.colorScale=i.scaleOrdinal().domain(this.cle.domain).range(this.cle.range)}invalidScaleType(t){throw new Error(`invalid property scaletype: ${t}.\n      Must be one of "categorical", "continuous", "discrete", "threshold".`)}}
 /**
      * @license
      * Copyright 2017 Google LLC
@@ -74,7 +74,7 @@ const st=(t,i)=>"method"===i.kind&&i.descriptor&&!("value"in i.descriptor)?{...i
         style="--color:${i(t)}"
       >
         ${t}
-      </li>`))}`}renderContinuous(){var t,i;if("continuous"!==this.cle.scaleType||null===this.cle.colorScale)return"";const{colorScale:s,marginTop:n,marginLeft:o,marginRight:r,tickSize:l,width:h,range:c}=this.cle,a=this.cle.marginBottom+l,d=this.cle.height+l,u=(null===(i=(t=s).interpolator)||void 0===i?void 0:i.call(t))||e.piecewise(e.interpolateHcl,c);return j`<image 
+      </li>`))}`}renderContinuous(){var t,i;if("continuous"!==this.cle.scaleType||null===this.cle.colorScale)return"";const{colorScale:s,marginTop:n,marginLeft:o,marginRight:r,tickSize:l,width:h,range:c}=this.cle,a=this.cle.marginBottom+l,d=this.cle.height+l,u=(null===(i=(t=s).interpolator)||void 0===i?void 0:i.call(t))||e.piecewise(e.interpolateHcl,c);return j`<image
       x=${o}
       y=${n}
       width=${h-r-o}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color-legend-element",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "color-legend-element",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-legend-element",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A custom element (web component) suitable for use as a legend in data visualizations",
   "main": "index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "color-legend-element",
   "version": "1.0.5",
   "description": "A custom element (web component) suitable for use as a legend in data visualizations",
-  "main": "build/color-legend-element.umd.js",
+  "main": "index.js",
   "module": "index.js",
   "type": "module",
   "types": "build/index.d.ts",

--- a/src/color-scale.ts
+++ b/src/color-scale.ts
@@ -25,16 +25,16 @@ export class ColorScaleSetter {
    */
   setColorScale() {
     switch (this.cle.scaleType) {
-      case ScaleType.Continuous:
+      case "continuous":
         this.setContinousColorScale();
         break;
-      case ScaleType.Discrete:
+      case "discrete":
         this.setDiscreteColorScale();
         break;
-      case ScaleType.Threshold:
+      case "threshold":
         this.setThresholdColorScale();
         break;
-      case ScaleType.Categorical:
+      case "categorical":
         this.setCategoricalColorScale();
         break;
       default:
@@ -88,7 +88,7 @@ export class ColorScaleSetter {
    * @param value string
    */
   private invalidScaleType(value: string) {
-    throw new Error(`invalid property scaletype: ${value}. 
+    throw new Error(`invalid property scaletype: ${value}.
       Must be one of "categorical", "continuous", "discrete", "threshold".`);
   }
 }

--- a/src/color-scale.ts
+++ b/src/color-scale.ts
@@ -7,7 +7,7 @@ import {
 } from "d3-scale";
 import { interpolateHcl } from "d3-interpolate";
 
-import { ColorScale, ScaleType } from "./types";
+import { ColorScale } from "./types";
 
 import { ColorLegendElement } from "./color-legend-element";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,8 +24,8 @@ export const DEFAULT_RANGE = [
 
 export const DEFAULT_TITLE_TEXT = "Color Legend Element";
 
-export const DEFAULT_MARK_TYPE = MarkType.Circle;
-export const DEFAULT_SCALE_TYPE = ScaleType.Continuous;
+export const DEFAULT_MARK_TYPE: MarkType = "circle";
+export const DEFAULT_SCALE_TYPE: ScaleType = "continuous";
 
 export const COLOR_SCALE_PROPS = [
   "domain",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -5,8 +5,6 @@ import { piecewise, interpolateHcl } from "d3-interpolate";
 import { ColorLegendElement } from "./color-legend-element";
 import {
   Interpolator,
-  ScaleType,
-  MarkType,
   ScaleOrdinal,
   ScaleSequential,
   ScaleThreshold,
@@ -27,9 +25,9 @@ export class Renderer {
     const title = this.cle.titleText
       ? html`<p class="legend-title">${this.cle.titleText}</p>`
       : "";
-    const svgClasses = { hidden: this.cle.scaleType === ScaleType.Categorical };
+    const svgClasses = { hidden: this.cle.scaleType === "categorical" };
     const categoricalClasses = {
-      hidden: this.cle.scaleType !== ScaleType.Categorical,
+      hidden: this.cle.scaleType !== "categorical",
       "categorical-container": true,
     };
 
@@ -63,14 +61,14 @@ export class Renderer {
    * @returns lit-html TemplateResult or empty string
    */
   renderCategorical(): TemplateResult | string {
-    if (this.cle.scaleType !== ScaleType.Categorical) {
+    if (this.cle.scaleType !== "categorical") {
       return "";
     }
     const { markType, colorScale, domain } = this.cle;
     const classes = {
       "legend-item": true,
-      line: markType === MarkType.Line,
-      circle: markType === MarkType.Circle,
+      line: markType === "line",
+      circle: markType === "circle",
     };
     return html`${(domain as string[]).map(
       (category) => html`<li
@@ -89,10 +87,7 @@ export class Renderer {
    * @returns lit-html TemplateResult or empty string
    */
   renderContinuous() {
-    if (
-      this.cle.scaleType !== ScaleType.Continuous ||
-      this.cle.colorScale === null
-    ) {
+    if (this.cle.scaleType !== "continuous" || this.cle.colorScale === null) {
       return "";
     }
 
@@ -113,7 +108,7 @@ export class Renderer {
       (colorScale as ScaleSequential<string>).interpolator?.() ||
       piecewise<string>(interpolateHcl, range as string[]);
 
-    return svg`<image 
+    return svg`<image
       x=${marginLeft}
       y=${marginTop}
       width=${width - marginRight - marginLeft}
@@ -129,8 +124,8 @@ export class Renderer {
    */
   renderDiscreteThreshold() {
     if (
-      this.cle.scaleType !== ScaleType.Discrete &&
-      this.cle.scaleType !== ScaleType.Threshold
+      this.cle.scaleType !== "discrete" &&
+      this.cle.scaleType !== "threshold"
     ) {
       return "";
     }
@@ -171,8 +166,7 @@ export class Renderer {
    * @returns lit-html TemplateResult or empty string
    */
   renderAxis(): TemplateResult | string {
-    if (!this.cle.xScale || this.cle.scaleType === ScaleType.Categorical)
-      return "";
+    if (!this.cle.xScale || this.cle.scaleType === "categorical") return "";
 
     const {
       ticks,

--- a/src/test/x-scale-axis_test.ts
+++ b/src/test/x-scale-axis_test.ts
@@ -2,7 +2,6 @@ import { fixture, assert } from "@open-wc/testing";
 import { html } from "lit/static-html.js";
 import { AxisTicksSetter } from "../x-scale-axis";
 import { ColorLegendElement } from "../color-legend-element";
-import { ScaleType } from "../types";
 
 suite("AxisTicksSetter", () => {
   test("is instanceOf", () => {
@@ -13,7 +12,7 @@ suite("AxisTicksSetter", () => {
 
   test("setXScale continuous", () => {
     const cle = new ColorLegendElement();
-    cle.scaleType = ScaleType.Continuous;
+    cle.scaleType = "continuous";
     const ats = new AxisTicksSetter(cle);
     ats.setXScale();
     assert.isNotNull(ats.xScale);
@@ -21,7 +20,7 @@ suite("AxisTicksSetter", () => {
 
   test("setXScale discrete", () => {
     const cle = new ColorLegendElement();
-    cle.scaleType = ScaleType.Discrete;
+    cle.scaleType = "discrete";
     cle.domain = [0, 1, 2, 3, 4, 5];
     const ats = new AxisTicksSetter(cle);
     ats.setXScale();
@@ -30,7 +29,7 @@ suite("AxisTicksSetter", () => {
 
   test("setXScale threshold", () => {
     const cle = new ColorLegendElement();
-    cle.scaleType = ScaleType.Threshold;
+    cle.scaleType = "threshold";
     cle.domain = [0, 1, 2, 3, 4, 5];
     const ats = new AxisTicksSetter(cle);
     ats.setXScale();
@@ -39,7 +38,7 @@ suite("AxisTicksSetter", () => {
 
   test("setXScale categorical", () => {
     const cle = new ColorLegendElement();
-    cle.scaleType = ScaleType.Categorical;
+    cle.scaleType = "categorical";
     const ats = new AxisTicksSetter(cle);
     ats.setXScale();
     assert.isNull(ats.xScale);
@@ -64,7 +63,7 @@ suite("AxisTicksSetter", () => {
     const expected = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
     const el = (await fixture(
       html`<color-legend
-        scaleType=${ScaleType.Discrete}
+        scaleType=${"discrete"}
         .domain=${[0.1, 1]}
         .range=${[
           "#fcfbfd",
@@ -88,7 +87,7 @@ suite("AxisTicksSetter", () => {
     const expected = [0, 2, 4, 10];
     const el = (await fixture(
       html`<color-legend
-        scaleType=${ScaleType.Threshold}
+        scaleType=${"threshold"}
         .domain=${expected}
       ></color-legend>`
     )) as ColorLegendElement;
@@ -99,7 +98,7 @@ suite("AxisTicksSetter", () => {
   test("handleAxisTicks continuous", async () => {
     const el = (await fixture(
       html`<color-legend
-        scaleType=${ScaleType.Continuous}
+        scaleType=${"continuous"}
         .domain=${[0, 100]}
       ></color-legend>`
     )) as ColorLegendElement;
@@ -110,7 +109,7 @@ suite("AxisTicksSetter", () => {
   test("handleAxisTicks categorical", async () => {
     const el = (await fixture(
       html`<color-legend
-        scaleType=${ScaleType.Categorical}
+        scaleType=${"categorical"}
         .domain=${["a", "b", "c"]}
       ></color-legend>`
     )) as ColorLegendElement;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,17 +35,10 @@ export type Interpolator<T> = (t: number) => T;
 
 export type TickFormatter = (d: number) => string;
 
-export const enum MarkType {
-  Rect = "rect",
-  Circle = "circle",
-  Line = "line",
-}
+/** the type of shape rendered when ScaleType is "categorical" */
+export type MarkType = "rect" | "circle" | "line";
 
-export const enum ScaleType {
-  Categorical = "categorical",
-  Continuous = "continuous",
-  Discrete = "discrete",
-  Threshold = "threshold",
-}
+/** available scales, similar to those of d3-scale */
+export type ScaleType = "categorical" | "continuous" | "discrete" | "threshold";
 
 export type ChangedProps = Map<string, number | string>;

--- a/src/x-scale-axis.ts
+++ b/src/x-scale-axis.ts
@@ -1,7 +1,7 @@
 import { scaleLinear } from "d3-scale";
 import { format } from "d3-format";
 import { ColorLegendElement } from "./color-legend-element";
-import { ScaleType, ScaleQuantize, XScale } from "./types";
+import { ScaleQuantize, XScale } from "./types";
 import { DEFAULT_TICKS, DEFAULT_TICK_FORMAT } from "./constants";
 
 export class AxisTicksSetter {
@@ -19,13 +19,13 @@ export class AxisTicksSetter {
   setXScale() {
     const { scaleType, marginLeft, width, marginRight } = this.cle;
     switch (scaleType) {
-      case ScaleType.Continuous:
+      case "continuous":
         this.xScale = scaleLinear()
           .domain(this.cle.domain as number[])
           .range([marginLeft, width - marginRight]);
         break;
-      case ScaleType.Discrete:
-      case ScaleType.Threshold:
+      case "discrete":
+      case "threshold":
         this.xScale = scaleLinear<number, number>()
           .domain([
             (this.cle.domain as number[])[0],
@@ -33,7 +33,7 @@ export class AxisTicksSetter {
           ])
           .rangeRound([marginLeft, width - marginRight]);
         break;
-      case ScaleType.Categorical:
+      case "categorical":
         // xScale is not used for ScaleType.Categorical
         this.xScale = null;
         break;
@@ -48,10 +48,7 @@ export class AxisTicksSetter {
    */
   handleAxisTicks() {
     const { scaleType } = this.cle;
-    if (
-      scaleType !== ScaleType.Continuous &&
-      scaleType !== ScaleType.Categorical
-    ) {
+    if (scaleType !== "continuous" && scaleType !== "categorical") {
       const [min, max] = this.xScale.domain() as [number, number];
       this.cle.tickValues = this.cle.tickValues || [
         min,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
     "plugins": [


### PR DESCRIPTION
- updates the package.json's "main" field to point to the root `index.js` barrel file to simplify imports with module bundlers
- converts the the types `MarkType` and `ScaleType` from `const enum` to regular `type` to support a wider range of TypeScript configurations and implementations that don't support `const enum` [such as Parcel's](https://parceljs.org/languages/typescript/).
- updates the `tsconfig.json` to explicitly set "useDefineForClassFields" to `false` as per recommendations by the [Lit docs for avoiding issues with class fields](https://lit.dev/docs/v2/components/properties/#avoiding-issues-with-class-fields).