### PR TITLE
update docs: add meta generator = eleventy

### DIFF
--- a/docs-src/_includes/baselayout.njk
+++ b/docs-src/_includes/baselayout.njk
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>{{ title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="Eleventy">
     <script defer src="./assets/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <script defer src="./assets/lit/polyfill-support.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/d3@7.3.0/dist/d3.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Color Legend Element</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="Eleventy">
     <script defer src="./assets/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <script defer src="./assets/lit/polyfill-support.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/d3@7.3.0/dist/d3.min.js"></script>


### PR DESCRIPTION
Adds a meta tag in the head to help let others know the site was built with EleventyJS.